### PR TITLE
Fix property name mismatch in checkAnswer API

### DIFF
--- a/src/pages/api/checkAnswer.ts
+++ b/src/pages/api/checkAnswer.ts
@@ -18,10 +18,10 @@ const parser = StructuredOutputParser.fromZodSchema(
       .describe(
         "explanation of why the user choosen userAnswer is correct/incorrect and a description of the correct userAnswer"
       ),
-    correct_userAnswer: z
+    correct_answer: z
       .string()
       .describe(
-        "the correct userAnswer from the 4 options listed to the trivia question"
+        "the correct answer from the 4 options listed to the trivia question"
       ),
     confidence: z
       .enum(["high", "medium", "low"])


### PR DESCRIPTION
## Summary
- ensure `checkAnswer` API returns `correct_answer` to match client interface

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684659a6514c8321b07e47def708aa0d