### PR TITLE
Add API docs to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ instructions; nested files override parent guidance. Some setups also check
 - Follow the TypeScript and Next.js patterns already present.
 - Run `npm run lint` before committing so ESLint passes.
 - Document any future test commands here for agents to run.
+  - Run `npm run test` to verify documentation.
 
 ### How the Agent Should Work
 - Focus exploration on the `src` directory.
@@ -36,6 +37,50 @@ This project is a Next.js 13 application written in TypeScript. It serves an AI 
 2. **Answer Checking** – `/api/checkAnswer` accepts the question and user option, queries OpenAI to confirm correctness, and returns an explanation.
 3. **Random Topic** – `/api/getRandomTriviaTopic` suggests a new trivia topic, avoiding previously used ones.
 4. **Rate Limiting** – each API call and page load is limited to 5 requests every 10 seconds per IP using Upstash.
+
+## API Endpoints
+
+### `POST /api/generateQuestion`
+**Body**
+```json
+{
+  "topic": "string",
+  "pastQuestions": [ { "question": "string", "options": ["string"] } ],
+  "difficulty": "string",
+  "language": "string"
+}
+```
+**Returns**
+```json
+{
+  "question": "string",
+  "options": ["string", "string", "string", "string"]
+}
+```
+
+### `POST /api/checkAnswer?topic=<string>`
+**Body**
+```json
+{
+  "question": "string | object",
+  "userSelectedOption": "string"
+}
+```
+**Returns**
+```json
+{
+  "correct": true,
+  "explanation": "string",
+  "correct_answer": "string",
+  "confidence": "high" | "medium" | "low"
+}
+```
+
+### `GET /api/getRandomTriviaTopic?pastTopics=<comma-separated>`
+Returns a string topic in the response body.
+
+### `POST /api/generateQuestionAndAnswer`
+Same input and output as `generateQuestion`. Currently unused but kept for reference.
 
 ## Development Notes
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node scripts/test-docs.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.0",

--- a/scripts/test-docs.js
+++ b/scripts/test-docs.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+const content = fs.readFileSync(path.join(__dirname, '..', 'AGENTS.md'), 'utf8');
+if (!content.includes('## API Endpoints')) {
+  console.error('AGENTS.md missing API Endpoints section');
+  process.exit(1);
+}
+console.log('Docs test passed');


### PR DESCRIPTION
## Summary
- document API endpoints in `AGENTS.md`
- note `npm run test` command
- add small test verifying docs

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68466a2e7a888321bc80b2b3ba41303c